### PR TITLE
VULN-42184 Bump the Werkzeug version for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask==2.2.2
 itsdangerous==2.2.0
 Jinja2==3.1.4
 MarkupSafe==3.0.2
-Werkzeug==2.2.2
+Werkzeug==3.0.3


### PR DESCRIPTION
JIRA Ticket: [VULN-42184](https://yext.atlassian.net/browse/VULN-42184)

## Summary

Affected versions of Werkzeug are vulnerable to Cross-Site Request Forgery (CSRF). Exploitation requires the attacker to guess a URL in the developer's application that will trigger the debugger AND requires the attacker to get the developer to interact with a domain and subdomain they control, and enter the debugger PIN.


[VULN-42184]: https://yext.atlassian.net/browse/VULN-42184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ