### PR TITLE
VULN-42185 Bump the Flask and Werkzeug versions for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.1.7
-Flask==2.2.2
+Flask==3.1.2
 itsdangerous==2.2.0
 Jinja2==3.1.4
 MarkupSafe==3.0.2
-Werkzeug==3.0.3
+Werkzeug==3.1.5


### PR DESCRIPTION
JIRA Ticket: [VULN-42185](https://yext.atlassian.net/browse/VULN-42185)

## Summary

flask versions before 2.2.5, and versions >= 2.3.0 before 2.3.2 are vulnerable to Use Of Persistent Cookies Containing Sensitive Information. This is due to Flask only setting the `Vary: Cookie` header when the session is accessed or modified, not when it is refreshed (re-sent to update the expiration) without being accessed or modified.

[VULN-42185]: https://yext.atlassian.net/browse/VULN-42185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ